### PR TITLE
Add `sd_product` tag to auto-gen pr. layout

### DIFF
--- a/layouts/auto_generated_product.tpl
+++ b/layouts/auto_generated_product.tpl
@@ -5,6 +5,8 @@
   <head prefix="og: http://ogp.me/ns#">
     {% include "edicy-tools-variables" %}
     {% include "html-head" common_page: true %}
+
+    {% sd_product %}
   </head>
   <body class="item-page product-page main-menu-not-fitting{% if site.search.enabled %} search-enabled{% endif %}">
 


### PR DESCRIPTION
Include `sd_product` tag in Auto-rendered Product layout to render out product structured data.

Closes #129 